### PR TITLE
TST add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+
+# command to install dependencies
+install:
+  - "pip install jinja2 --use-mirrors"
+  - "pip install numpy --use-mirrors"  # skip tests which require numpy is not present?
+#  - "pip install -r requirements.txt --use-mirrors"
+# command to run tests
+
+script: nosetests


### PR DESCRIPTION
Adds travis ci, see http://about.travis-ci.org/docs/user/getting-started/

_[jinja2](https://github.com/mitsuhiko/jinja2) doesn't support 3.1 or 3.2 (it uses u'' syntax) so these builds are not included (the tests fail!)._

Also, numpy is currently a hard dependency in the tests, however some tests should probably skip if numpy is not available (so this case can be tested).
