### PR TITLE
Escape strings before putting them into XML.

### DIFF
--- a/pyexcelerate/Worksheet.py
+++ b/pyexcelerate/Worksheet.py
@@ -4,6 +4,7 @@ from . import Format
 from .DataTypes import DataTypes
 from . import six
 from datetime import datetime
+from xml.sax.saxutils import escape
 
 class Worksheet(object):
 	def __init__(self, name, workbook, data=None):
@@ -122,7 +123,7 @@ class Worksheet(object):
 			if type == DataTypes.NUMBER:
 				self._cell_cache[cell] = '"><v>%.15g</v></c>' % (cell)
 			elif type == DataTypes.INLINE_STRING:
-				self._cell_cache[cell] = '" t="inlineStr"><is><t>%s</t></is></c>' % (cell)
+				self._cell_cache[cell] = '" t="inlineStr"><is><t>%s</t></is></c>' % escape(cell)
 			elif type == DataTypes.DATE:
 				self._cell_cache[cell] = '"><v>%s</v></c>' % (DataTypes.to_excel_date(cell))
 			elif type == DataTypes.FORMULA:

--- a/pyexcelerate/tests/test_DataTypes.py
+++ b/pyexcelerate/tests/test_DataTypes.py
@@ -28,6 +28,13 @@ def test_numpy():
 	eq_(DataTypes.get_type(ws[1][1].value), DataTypes.NUMBER)
 	wb.save(get_output_path("numpy-test.xlsx"))
 
+def test_ampersand_escaping():
+	testData = [["http://example.com/?one=1&two=2"]]
+	wb = Workbook()
+	ws = wb.new_sheet("Test 1", data=testData)
+	data = list(ws.get_xml_data())
+	assert "http://example.com/?one=1&amp;two=2" in data[0][1][0]
+
 def test_to_excel_date():
 	eq_(DataTypes.to_excel_date(datetime(1900, 1, 1, 0, 0, 0)), 1.0)
 	eq_(DataTypes.to_excel_date(datetime(1900, 1, 1, 12, 0, 0)), 1.5)
@@ -39,4 +46,3 @@ def test_to_excel_date():
 	# check excel's improper handling of leap year
 	eq_(DataTypes.to_excel_date(datetime(1900, 2, 28, 0, 0, 0)), 59.0)
 	eq_(DataTypes.to_excel_date(datetime(1900, 3, 1, 0, 0, 0)), 61.0)
-	


### PR DESCRIPTION
Strings are not escaped before being put into the XML. This leads to malformed XML when the string contains for example an ampersand.
