### PR TITLE
Use row/column style for cells if they exist

### DIFF
--- a/pyexcelerate/Worksheet.py
+++ b/pyexcelerate/Worksheet.py
@@ -209,9 +209,13 @@ class Worksheet(object):
 		for x, row in six.iteritems(self._cells):
 			row_data = []
 			for y, cell in six.iteritems(self._cells[x]):
-				if x not in self._styles or y not in self._styles[x]:
-					style = None
-				else:
+				if x in self._styles and y in self._styles[x]:
 					style = self._styles[x][y]
+				elif x in self._row_styles:
+					style = self._row_styles[x]
+				elif y in self._col_styles:
+					style = self._col_styles[y]
+				else:
+					style = None
 				row_data.append(self.__get_cell_data(cell, x, y, style))
 			yield x, row_data


### PR DESCRIPTION
Setting the style on a column/row only affects new cells added in Excel. Cells inserted using PyExcelerate, after setting a column or row style, don't use those styles. This change looks for styles on the row and then column if none is found on the cell itself.

If both row and column styles are set, use the row style.

I understand this might not be how you actually want row and column styles to behave, in which case I can update the docs to reflect their limitations instead of making this change. But it's pretty handy - my use case is importing in bulk via the `data` argument to `new_sheet()`, and then simply calling `set_col_style()` for each column that I want to have special formatting.
