### PR TITLE
[fix] add Color module

### DIFF
--- a/pyexcelerate/__init__.py
+++ b/pyexcelerate/__init__.py
@@ -4,6 +4,7 @@ from .Fill import Fill
 from .Font import Font
 from .Format import Format
 from .Alignment import Alignment
+from .Color import Color
 
 try:
 	import pkg_resources


### PR DESCRIPTION
Hi, I found a bug about Color module. That makes an error "TypeError: 'module' object is not callable".
**init**.py file has no Color module.
I think it must be a mistake. So I edit **init**.py file and then works well.

I will be happy you apply this request :)
