### PR TITLE
Add support for worksheet panes

### DIFF
--- a/pyexcelerate/Panes.py
+++ b/pyexcelerate/Panes.py
@@ -1,0 +1,29 @@
+from . import Range
+from .Utility import to_unicode
+
+
+class Panes(object):
+	def __init__(self, x=None, y=None, freeze=True):
+		self.x = x or 0
+		self.y = y or 0
+		self.freeze = freeze
+
+	def __bool__(self):
+		return any((self.x, self.y))
+
+	def __nonzero__(self):
+		return self.__bool__()
+
+	def __eq__(self, other):
+		return self.x == other.x and self.y == other.y and self.freeze == other.freeze
+
+	def get_xml(self):
+		attrs = {'topLeftCell': Range.Range.coordinate_to_string((self.y + 1, self.x + 1))}
+		if self.freeze:
+			attrs['state'] = 'frozen'
+		if self.x:
+			attrs['xSplit'] = self.x
+		if self.y:
+			attrs['ySplit'] = self.y
+		attr_str = " ".join('%s="%s"' % item for item in sorted(attrs.items()))
+		return to_unicode("<pane %s/>" % attr_str)

--- a/pyexcelerate/Worksheet.py
+++ b/pyexcelerate/Worksheet.py
@@ -1,3 +1,4 @@
+from . import Panes
 from . import Range
 from . import Style
 from . import Format
@@ -7,6 +8,7 @@ import six
 import math
 from datetime import datetime
 from xml.sax.saxutils import escape
+
 
 class Worksheet(object):
 	def __init__(self, name, workbook, data=None, force_name=False):
@@ -21,6 +23,7 @@ class Worksheet(object):
 		self._parent = workbook
 		self._merges = [] # list of Range objects
 		self._attributes = {}
+		self._panes = Panes.Panes()
 		if data is not None:
 			for x, row in enumerate(data, 1):
 				for y, cell in enumerate(row, 1):
@@ -39,6 +42,16 @@ class Worksheet(object):
 			if key not in self._cells:
 				self._cells[key] = {}
 			return Range.Range((key, 1), (key, float('inf')), self) # return a row range
+
+	@property
+	def panes(self):
+		return self._panes
+
+	@panes.setter
+	def panes(self, panes):
+		if not isinstance(panes, Panes.Panes):
+			raise TypeError("Worksheet.panes must be of type Panes")
+		self._panes = panes
 
 	@property
 	def stylesheet(self):

--- a/pyexcelerate/__init__.py
+++ b/pyexcelerate/__init__.py
@@ -5,6 +5,7 @@ from .Font import Font
 from .Format import Format
 from .Alignment import Alignment
 from .Color import Color
+from .Worksheet import Panes
 
 try:
 	import pkg_resources

--- a/pyexcelerate/templates/xl/worksheets/sheet.xml
+++ b/pyexcelerate/templates/xl/worksheets/sheet.xml
@@ -2,6 +2,7 @@
 <worksheet mc:Ignorable="x14ac" xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac">
     <sheetViews>
         <sheetView tabSelected="1" workbookViewId="0">
+            {% if worksheet.panes %}{{ worksheet.panes.get_xml() }}{% endif %}
             <selection activeCell="A1" sqref="A1" />
         </sheetView>
     </sheetViews>

--- a/pyexcelerate/tests/test_Panes.py
+++ b/pyexcelerate/tests/test_Panes.py
@@ -1,0 +1,31 @@
+from ..Panes import Panes
+from ..Workbook import Workbook
+
+from nose.tools import eq_, ok_, assert_raises
+from pyexcelerate.Utility import to_unicode
+
+import sys
+
+
+def test_panes_boolean():
+	ok_(not Panes())
+	ok_(Panes(x=1))
+	ok_(Panes(y=1))
+
+
+def test_panes_output():
+	eq_(to_unicode('<pane state="frozen" topLeftCell="A2" ySplit="1"/>'), Panes(y=1).get_xml())
+	eq_(to_unicode('<pane topLeftCell="B1" xSplit="1"/>'), Panes(x=1, freeze=False).get_xml())
+	eq_(to_unicode('<pane state="frozen" topLeftCell="C3" xSplit="2" ySplit="2"/>'), Panes(x=2, y=2).get_xml())
+
+
+def test_worksheet_property():
+	wb = Workbook()
+	ws = wb.new_sheet("Test 1")
+	ws.panes = Panes(x=1, y=2)
+	eq_(ws.panes, Panes(x=1, y=2))
+
+	if sys.version_info >= (2, 7):
+		# assert_raises not supported before Python 2.7
+		with assert_raises(TypeError):
+			ws.panes = "banana"


### PR DESCRIPTION
This allows splitting the view, into both frozen and unfrozen panes. I haven't tested this extensively yet.

Any thoughts on the API?

Example usage:

```python
# freeze the first row
worksheet.panes = Panes(y=1)
```