### PR TITLE
Fix module-level Panes import

### DIFF
--- a/pyexcelerate/__init__.py
+++ b/pyexcelerate/__init__.py
@@ -5,7 +5,7 @@ from .Font import Font
 from .Format import Format
 from .Alignment import Alignment
 from .Color import Color
-from .Worksheet import Panes
+from .Panes import Panes
 
 try:
 	import pkg_resources


### PR DESCRIPTION
When I moved ``Panes`` into its own file, I didn't update the import in ``__init__.py``. This fixes that.