### PR TITLE
Style hashes incomplete.

### DIFF
--- a/pyexcelerate/Alignment.py
+++ b/pyexcelerate/Alignment.py
@@ -80,7 +80,7 @@ class Alignment(object):
 			return self._vertical == other._vertical and self._rotation == other._rotation and self._horizontal == other._horizontal and self._wrap_text == other._wrap_text
 	
 	def __hash__(self):
-		return hash((self._horizontal))
+		return hash((self._horizontal, self._vertical, self._rotation, self._wrap_text))
 	
 	def __str__(self):
 		return "Align: %s %s %s" % (self._horizontal, self._vertical, self._rotation)

--- a/pyexcelerate/Border.py
+++ b/pyexcelerate/Border.py
@@ -60,4 +60,4 @@ class Border(object):
 			return self._color == other._color and self._style == other._style
 			
 	def __hash__(self):
-		return hash(self._style)
+		return hash(self._color, self._style)

--- a/pyexcelerate/Borders.py
+++ b/pyexcelerate/Borders.py
@@ -92,4 +92,4 @@ class Borders(object):
 			return self._right == other._right and self._bottom == other._bottom and self._top == other._top and self._left == other._left
 	
 	def __hash__(self):
-		return hash((self._top, self._left))
+		return hash((self._top, self._left, self._bottom, self._right))

--- a/pyexcelerate/Font.py
+++ b/pyexcelerate/Font.py
@@ -68,7 +68,7 @@ class Font(object):
 			return self._to_tuple() == other._to_tuple()
 
 	def __hash__(self):
-		return hash((self.bold, self.italic, self.underline, self.strikethrough))
+		return hash((self.bold, self.italic, self.underline, self.strikethrough, self.family, self.size, self._color))
 
 	def _to_tuple(self):
 		return (self.bold, self.italic, self.underline, self.strikethrough, self.family, self.size, self._color)

--- a/pyexcelerate/Style.py
+++ b/pyexcelerate/Style.py
@@ -78,7 +78,7 @@ class Style(object):
 			return "<xf xfId=\"0\"  %s applyAlignment=\"1\">%s</xf>" % (" ".join(tag), self._alignment.get_xml_string())
 		
 	def __hash__(self):
-		return hash((self._font, self._fill))
+		return hash((self._font, self._fill, self._format, self._alignment, self._borders, self._size))
 	
 	def __eq__(self, other):
 		if other is None:


### PR DESCRIPTION
Style hashes are incomplete, not accounting for quite a few style attributes. This prevents usage of many style cominations as they are thrown out during style alignment.
