### PR TITLE
Add ability to save workbook to an open file handle

### DIFF
--- a/pyexcelerate/Workbook.py
+++ b/pyexcelerate/Workbook.py
@@ -1,7 +1,7 @@
 from . import Worksheet
 from .Writer import Writer
 from . import Utility
-from io import IOBase
+import six
 import time
 
 
@@ -94,8 +94,8 @@ class Workbook(object):
         self._writer.save(file_handle)
 
     def save(self, filename_or_filehandle):
-        if isinstance(filename_or_filehandle, IOBase):
-            self._save(filename_or_filehandle)
-        else:
+        if isinstance(filename_or_filehandle, six.string_types):
             with open(filename_or_filehandle, 'wb') as fp:
                 self._save(fp)
+        else:
+            self._save(filename_or_filehandle)

--- a/pyexcelerate/Workbook.py
+++ b/pyexcelerate/Workbook.py
@@ -1,6 +1,7 @@
 from . import Worksheet
 from .Writer import Writer
 from . import Utility
+from io import IOBase
 import time
 
 
@@ -92,6 +93,9 @@ class Workbook(object):
         self._align_styles()
         self._writer.save(file_handle)
 
-    def save(self, filename):
-        with open(filename, 'wb') as fp:
-            self._save(fp)
+    def save(self, filename_or_filehandle):
+        if isinstance(filename_or_filehandle, IOBase):
+            self._save(filename_or_filehandle)
+        else:
+            with open(filename_or_filehandle, 'wb') as fp:
+                self._save(fp)

--- a/pyexcelerate/tests/test_Workbook.py
+++ b/pyexcelerate/tests/test_Workbook.py
@@ -24,6 +24,15 @@ def test_save():
 	ws = wb.new_sheet("Test 1", data=testData)
 	wb.save(get_output_path("test.xlsx"))
 
+def test_save_to_filehandle():
+	ROWS = 65
+	COLUMNS = 100
+	wb = Workbook()
+	testData = [[1] * COLUMNS] * ROWS
+	ws = wb.new_sheet("Test 1", data=testData)
+	with open(get_output_path("test.xlsx"), "wb") as output_fp:
+		wb.save(output_fp)
+
 def test_formulas():
 	wb = Workbook()
 	ws = wb.new_sheet("test")


### PR DESCRIPTION
Hi,
It would be nice to be able to pass an open filehandle to the workbook save, instead of solely allowing a filename. This can be useful for example to save the workbook somewhere that cannot be referenced by a filename, such as a `BytesIO` object in memory.

My apologies in advance if this has been discussed or ruled out before, I am happy to discuss or make changes if you like. Thank you for sharing this library, it suits a use-case I have very well and is much faster than the other libraries I have benchmarked.