### PR TITLE
Update Worksheet.py

### DIFF
--- a/pyexcelerate/Worksheet.py
+++ b/pyexcelerate/Worksheet.py
@@ -182,6 +182,8 @@ class Worksheet(object):
         # boolean values are treated oddly in dictionaries, manually override
         type = DataTypes.get_type(cell)
 
+        z = None #sometimes not correct datatype breaks function. Error at line 207: "UnboundLocalError: local variable 'z' referenced before assignment, see return in this function"   
+        
         if type == DataTypes.NUMBER:
             if math.isnan(cell):
                 z = '" t="e"><v>#NUM!</v></c>'
@@ -198,7 +200,10 @@ class Worksheet(object):
             z = '"><f>%s</f></c>' % (cell[1:]) # Remove equals sign.
         elif type == DataTypes.BOOLEAN:
             z = '" t="b"><v>%d</v></c>' % (cell)
-
+        
+        if z is None:
+            raise NameError "Cell datatype {} is not correct".format(type) # set cell data
+        
         if style:
             return "<c r=\"%s\" s=\"%d%s" % (Range.Range.coordinate_to_string(
                 (x, y)), style.id, z)


### PR DESCRIPTION
correction of error while cell datatype is not correct.
Example, 

---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
<ipython-input-2-5641346fadb0> in <module>()
    894     wb.new_sheet(category, data=ll)
    895 
--> 896 wb.save(excel_file)
    897 print('Done! File saved at {}'.format(excel_file))

E:\ANACONDA\envs\MSCOCO\lib\site-packages\pyexcelerate\Workbook.py in save(self, filename)
     95     def save(self, filename):
     96         with open(filename, 'wb') as fp:
---> 97             self._save(fp)

E:\ANACONDA\envs\MSCOCO\lib\site-packages\pyexcelerate\Workbook.py in _save(self, file_handle)
     91     def _save(self, file_handle):
     92         self._align_styles()
---> 93         self._writer.save(file_handle)
     94 
     95     def save(self, filename):

E:\ANACONDA\envs\MSCOCO\lib\site-packages\pyexcelerate\Writer.py in save(self, f)
     71                 with zf.open(
     72                         "xl/worksheets/sheet%s.xml" % (index), mode="w") as f:
---> 73                     for s in sheetStream:
     74                         f.write(s.encode('utf-8'))
     75             except RuntimeError:

E:\ANACONDA\envs\MSCOCO\lib\site-packages\jinja2\environment.py in generate(self, *args, **kwargs)
   1043         else:
   1044             return
-> 1045         yield self.environment.handle_exception(exc_info, True)
   1046 
   1047     def generate_async(self, *args, **kwargs):

E:\ANACONDA\envs\MSCOCO\lib\site-packages\jinja2\environment.py in handle_exception(self, exc_info, rendered, source_hint)
    778             self.exception_handler(traceback)
    779         exc_type, exc_value, tb = traceback.standard_exc_info
--> 780         reraise(exc_type, exc_value, tb)
    781 
    782     def join_path(self, template, parent):

E:\ANACONDA\envs\MSCOCO\lib\site-packages\jinja2\_compat.py in reraise(tp, value, tb)
     35     def reraise(tp, value, tb=None):
     36         if value.__traceback__ is not tb:
---> 37             raise value.with_traceback(tb)
     38         raise value
     39 

E:\ANACONDA\envs\MSCOCO\lib\site-packages\pyexcelerate\templates\xl\worksheets\sheet.xml in top-level template code()
      9     <sheetFormatPr defaultRowHeight="15" x14ac:dyDescent="0.25"/>
     10         {% if worksheet.col_styles %}<cols>{% for x, column in worksheet.col_styles %}{{ worksheet.get_col_xml_string(x) }}</col>{% endfor %}</cols>{% endif %}
---> 11     <sheetData>{% for x, row in worksheet.get_xml_data() %}{{ worksheet.get_row_xml_string(x) }}{% for cell in row %}{{ cell }}{% endfor %}</row>{% endfor %}</sheetData>
     12     {% if worksheet.merges.__len__() > 0 %}<mergeCells>{% for merge in worksheet.merges %}<mergeCell ref="{{ merge.__str__() }}"/>{% endfor %}</mergeCells>{% endif %}
     13     <pageMargins left="0.7" right="0.7" top="0.75" bottom="0.75" header="0.3" footer="0.3" />

E:\ANACONDA\envs\MSCOCO\lib\site-packages\pyexcelerate\Worksheet.py in get_xml_data(self)
    286                 else:
    287                     style = None
--> 288                 row_data.append(self.__get_cell_data(cell, x, y, style))
    289             yield x, row_data

E:\ANACONDA\envs\MSCOCO\lib\site-packages\pyexcelerate\Worksheet.py in __get_cell_data(self, cell, x, y, style)
    205         else:
    206             return "<c r=\"%s%s" % (Range.Range.coordinate_to_string((x, y)),
--> 207                                     z)
    208 
    209     def get_col_xml_string(self, col):

UnboundLocalError: local variable 'z' referenced before assignment