### PR TITLE
Cast non-Excel-primitives to string instead of throwing an error

### DIFF
--- a/pyexcelerate/DataTypes.py
+++ b/pyexcelerate/DataTypes.py
@@ -52,7 +52,7 @@ class DataTypes(object):
         elif isinstance(value, (datetime, date, time)):
             return DataTypes.DATE
         else:
-            return DataTypes.ERROR
+            return DataTypes.INLINE_STRING
 
     @staticmethod
     def to_excel_date(d):

--- a/pyexcelerate/Worksheet.py
+++ b/pyexcelerate/Worksheet.py
@@ -188,7 +188,7 @@ class Worksheet(object):
                 z = '"><v>%.15g</v></c>' % (cell)
         elif type == DataTypes.INLINE_STRING:
             z = '" t="inlineStr"><is><t>%s</t></is></c>' % escape(
-                to_unicode(cell))
+                to_unicode(str(cell)))
         elif type == DataTypes.DATE:
             z = '"><v>%s</v></c>' % (DataTypes.to_excel_date(cell))
         elif type == DataTypes.FORMULA:


### PR DESCRIPTION
Sometimes, data to be written to Excel might be a non-Excel-primitive object which can be meaningfully written to a spreadsheet.  Currently, the code detects the `type` of each cell, and if unrecognized, sets to `DataTypes.ERROR`.  This PR changes this to `DataTypes.INLINE_STRING` and also changes `__get_cell_data()` to cast `cell` to `str(cell)` so that if, say, we want to write a Python `set` or other object to a spreadsheet, now we can.  

This may involve too much overhead to cast every `cell` to `str`, in which case i can massage data ahead of time to cast `sets` to `strs`.    If that's the case, then I'd like to change the `print()` so it prints the _Python_ type of the cell rather than the `DataTypes` type. 