### PR TITLE
docs: fix simple typo, joind -> joined

### DIFF
--- a/pyexcelerate/Range.py
+++ b/pyexcelerate/Range.py
@@ -17,7 +17,7 @@ COORD2COLUMN = (
     # remove duplicates in collection by taking list(dict.fromkeys( collection ))
     list(
         OrderedDict.fromkeys(
-            # joind the items together so that ["","","A"] => "A", ["","R","Z"] => "RZ", ...
+            # joined the items together so that ["","","A"] => "A", ["","R","Z"] => "RZ", ...
             map(
                 "".join,
                 # build iterator with all combination of 3 items in the list ["", "A", "B", ..., "Z"]


### PR DESCRIPTION
There is a small typo in pyexcelerate/Range.py.

Should read `joined` rather than `joind`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md