### PR TITLE
Add ability to hide worksheets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -363,6 +363,20 @@ attribute as well. This permits you to modify the style at a later time.
     ws[1][1].style.font = font
     wb.save("output.xlsx")
 
+Hidden sheet
+~~~~~~~~~~~~
+
+PyExcelerate supports adding hidden sheets. Note that the first sheet cannot be hidden.
+
+::
+
+    from pyexcelerate import Workbook
+
+    wb = Workbook()
+    ws = wb.new_sheet("visible sheet")
+    ws = wb.new_sheet("hidden sheet", hidden=True)
+    wb.save("output.xlsx")
+
 Packaging with PyInstaller
 --------------------------
 

--- a/pyexcelerate/Workbook.py
+++ b/pyexcelerate/Workbook.py
@@ -33,8 +33,8 @@ class Workbook(object):
                 )
         self._worksheets.append(worksheet)
 
-    def new_sheet(self, sheet_name, data=None, force_name=False):
-        worksheet = Worksheet.Worksheet(sheet_name, self, data, force_name)
+    def new_sheet(self, sheet_name, data=None, force_name=False, hidden=False):
+        worksheet = Worksheet.Worksheet(sheet_name, self, data, force_name, hidden)
         self.add_sheet(worksheet)
         return worksheet
 

--- a/pyexcelerate/Worksheet.py
+++ b/pyexcelerate/Worksheet.py
@@ -65,10 +65,11 @@ class Worksheet(object):
         "_attributes",
         "_panes",
         "_show_grid_lines",
+        "hidden",
         "auto_filter",
     )
 
-    def __init__(self, name, workbook, data=None, force_name=False):
+    def __init__(self, name, workbook, data=None, force_name=False, hidden=False):
         self._columns = 0  # cache this for speed
         if len(name) > 31 and not force_name:
             # http://stackoverflow.com/questions/3681868/is-there-a-limit-on-an-excel-worksheets-name-length
@@ -86,6 +87,7 @@ class Worksheet(object):
         self._attributes = {}
         self._panes = Panes.Panes()
         self._show_grid_lines = True
+        self.hidden = hidden
         self.auto_filter = False
         if data is not None:
             # Iterate over the data to ensure we receive a copy of immutables.

--- a/pyexcelerate/templates/xl/workbook.xml
+++ b/pyexcelerate/templates/xl/workbook.xml
@@ -7,7 +7,7 @@
     </bookViews>
     <sheets>
         {% for index, sheet in workbook.get_xml_data() %}
-        <sheet name="{{ sheet.name }}" sheetId="{{ index }}" r:id="rId{{ index }}" />
+        <sheet name="{{ sheet.name }}" sheetId="{{ index }}" r:id="rId{{ index }}" {% if sheet.hidden %}state="hidden" {% endif %}/>
         {% endfor %}
     </sheets>
     <calcPr calcId="145621" />

--- a/pyexcelerate/tests/test_Workbook.py
+++ b/pyexcelerate/tests/test_Workbook.py
@@ -242,3 +242,11 @@ def test_show_grid_lines():
     ws = wb.new_sheet("default_with_grid_lines")
     ws[1][1].value = "even more data"
     wb.save(get_output_path("grid_lines.xlsx"))
+
+
+def test_hidden_sheet():
+    wb = Workbook()
+    wb.new_sheet("Visible sheet", hidden=False)
+    wb.new_sheet("Hidden sheet", hidden=True)
+    wb.new_sheet("Another hidden sheet", hidden=True)
+    wb.save(get_output_path("hidden_sheet.xlsx"))


### PR DESCRIPTION
Adds the ability for a worksheet to be hidden. These are generally useful for reference data and lookups. Note that the first sheet cannot be hidden in Excel.

Example file attached from the test with two hidden sheets.
[hidden_sheet.xlsx](https://github.com/user-attachments/files/15764816/hidden_sheet.xlsx)
